### PR TITLE
Fixed theme being tied to windows' theme when it was set manually

### DIFF
--- a/AuroraVisionLauncher/App.xaml
+++ b/AuroraVisionLauncher/App.xaml
@@ -28,8 +28,6 @@
                         x:Key="CustomToUnderlineConverter"
                         FalseValue="None"
                         TrueValue="Underline" />
-                    <theming:SuperLibraryThemeProvider x:Key="{x:Static theming:SuperLibraryThemeProvider.DefaultInstance}" />
-
                 </ResourceDictionary>
                 <!--
                     MahApps.Metro resource dictionaries.

--- a/AuroraVisionLauncher/Services/ThemeSelectorService.cs
+++ b/AuroraVisionLauncher/Services/ThemeSelectorService.cs
@@ -60,53 +60,6 @@ Pink - #FFF472D0
 Mauve - #FF76608A
  */
 
-public class SuperLibraryThemeProvider : LibraryThemeProvider
-{
-    /// <inheritdoc/>
-    public static new readonly SuperLibraryThemeProvider DefaultInstance = new SuperLibraryThemeProvider();
-
-    public SuperLibraryThemeProvider() : base(true)
-    {
-
-    }
-
-    public override LibraryTheme? GetLibraryTheme(DictionaryEntry dictionaryEntry)
-    {
-        return base.GetLibraryTheme(dictionaryEntry);
-    }
-
-    public override IEnumerable<LibraryTheme> GetLibraryThemes()
-    {
-        return base.GetLibraryThemes();
-    }
-
-    protected override bool IsPotentialThemeResourceDictionary(DictionaryEntry dictionaryEntry)
-    {
-        return base.IsPotentialThemeResourceDictionary(dictionaryEntry);
-    }
-
-    public override void FillColorSchemeValues(Dictionary<string, string> values, RuntimeThemeColorValues colorValues)
-    {
-        throw new ArgumentException();
-        // Check if all needed parameters are not null
-        if (values is null)
-            throw new ArgumentNullException(nameof(values));
-        if (colorValues is null)
-            throw new ArgumentNullException(nameof(colorValues));
-
-        // Add the values you like to override
-        values.Add("MahApps.Colors.AccentBase", "[AccentBaseColor]");
-        values.Add("MahApps.Colors.Accent", "[AccentColor]");
-        values.Add("MahApps.Colors.Accent2", "[AccentColor2]");
-        values.Add("MahApps.Colors.Accent3", "[AccentColor3]");
-        values.Add("MahApps.Colors.Accent4", "[AccentColor4]");
-
-        values.Add("MahApps.Colors.Highlight", "[HighlightColor]");
-        values.Add("MahApps.Colors.IdealForeground", colorValues.IdealForegroundColor.ToString(CultureInfo.InvariantCulture));
-    }
-
-}
-
 public class ThemeSelectorService : IThemeSelectorService
 {
     //private const string _hcDarkTheme = "pack://application:,,,/Styles/Themes/HC.Dark.Blue.xaml";
@@ -135,9 +88,8 @@ public class ThemeSelectorService : IThemeSelectorService
         // TODO: Mahapps.Metro supports syncronization with high contrast but you have to provide custom high contrast themes
         // We've added basic high contrast dictionaries for Dark and Light themes
         // Please complete these themes following the docs on https://mahapps.com/docs/themes/thememanager#creating-custom-themes
-        ThemeManager.Current.RegisterLibraryThemeProvider(SuperLibraryThemeProvider.DefaultInstance);
-        ThemeManager.Current.AddLibraryTheme(new LibraryTheme(new Uri(_darkTheme), SuperLibraryThemeProvider.DefaultInstance));
-        ThemeManager.Current.AddLibraryTheme(new LibraryTheme(new Uri(_lightTheme), SuperLibraryThemeProvider.DefaultInstance));
+        ThemeManager.Current.AddLibraryTheme(new LibraryTheme(new Uri(_darkTheme), libraryThemeProvider: null));
+        ThemeManager.Current.AddLibraryTheme(new LibraryTheme(new Uri(_lightTheme), libraryThemeProvider: null));
         //ThemeManager.Current.AddLibraryTheme(new LibraryTheme(new Uri(_hcDarkTheme), MahAppsLibraryThemeProvider.DefaultInstance));
         //ThemeManager.Current.AddLibraryTheme(new LibraryTheme(new Uri(_hcLightTheme), MahAppsLibraryThemeProvider.DefaultInstance));
         var theme = GetCurrentTheme();

--- a/AuroraVisionLauncher/Services/ThemeSelectorService.cs
+++ b/AuroraVisionLauncher/Services/ThemeSelectorService.cs
@@ -65,9 +65,9 @@ public class SuperLibraryThemeProvider : LibraryThemeProvider
     /// <inheritdoc/>
     public static new readonly SuperLibraryThemeProvider DefaultInstance = new SuperLibraryThemeProvider();
 
-    public SuperLibraryThemeProvider():base(true)
+    public SuperLibraryThemeProvider() : base(true)
     {
-            
+
     }
 
     public override LibraryTheme? GetLibraryTheme(DictionaryEntry dictionaryEntry)
@@ -122,7 +122,7 @@ public class ThemeSelectorService : IThemeSelectorService
 
     public ThemeSelectorService()
     {
-     
+
     }
 
 
@@ -179,19 +179,18 @@ public class ThemeSelectorService : IThemeSelectorService
         App.Current.Properties[_themeKey] = themeEnum.ToString();
         App.Current.Properties[_customThemeColorKey] = customColor;
     }
-
+    /// <summary>
+    /// Sync with general theme (dark/light) and accent color.
+    /// </summary>
+    private const ThemeSyncMode SystemThemeSyncMode = ThemeSyncMode.SyncWithAppMode | ThemeSyncMode.SyncWithAccent;
+    /// <summary>
+    /// Do not sync at all.
+    /// </summary>
+    private const ThemeSyncMode ManualThemeSyncMode = ThemeSyncMode.DoNotSync;
     private static void SyncTheme(AppTheme themeEnum)
     {
-            ThemeManager.Current.ThemeSyncMode = ThemeSyncMode.SyncAll;
-        if (themeEnum == AppTheme.System)
-        {
-        }
-            ThemeManager.Current.SyncTheme();
-        //else
-        //{
-        //    ThemeManager.Current.ThemeSyncMode = ThemeSyncMode.SyncWithHighContrast;
-        //    ThemeManager.Current.SyncTheme();
-        //}
+        ThemeManager.Current.ThemeSyncMode = themeEnum == AppTheme.System ? SystemThemeSyncMode : ManualThemeSyncMode;
+        ThemeManager.Current.SyncTheme();
     }
 
     public AppTheme GetCurrentTheme()


### PR DESCRIPTION
Previously even manual themes were tied to the system theme (`ThemeSyncMode.SyncWithAll` was used). 
Now System theme is synced with `SyncWithAppMode` nad `SyncWithAccent`, while the non-system themes are not synced at all (`DoNotSync`).


Also cleaned up the code a bit.