### PR TITLE
Selecting different version of same app will correctly update argument string

### DIFF
--- a/AuroraVisionLauncher/Models/LaunchOptions.cs
+++ b/AuroraVisionLauncher/Models/LaunchOptions.cs
@@ -38,6 +38,7 @@ public abstract partial class LaunchOptions : ObservableObject
     private string? _programPath;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ArgumentString))]
     private string? _applicationPath;
     public string ArgumentString
     {


### PR DESCRIPTION
Added `NotifyPropertyChangedFor(nameof(ArgumentString))` in LaunchOptions.