### PR TITLE
Now when launching only counts process with the same filename as app

### DIFF
--- a/AuroraVisionLauncher/Services/ProcessManagerService.cs
+++ b/AuroraVisionLauncher/Services/ProcessManagerService.cs
@@ -133,6 +133,10 @@ namespace AuroraVisionLauncher.Services
 
             foreach (var proc in rawProcesses)
             {
+                if (!string.Equals(proc.MainModule?.FileName, app.Path,StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
                 try
                 {
                     var simple = new SimpleProcess(proc, _messenger, app.Path);


### PR DESCRIPTION
It counted all process matching the name initially, only later it was corrected.